### PR TITLE
03.02 add data layer classes for user registration flow

### DIFF
--- a/agenda/data/build.gradle.kts
+++ b/agenda/data/build.gradle.kts
@@ -13,6 +13,6 @@ dependencies {
 
     // Coroutines
     implementation(libs.kotlinx.coroutines.core)
-    // Serialization
+    // Kotlinx Json for Serialization
     implementation(libs.kotlinx.serialization.json)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools" >
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".TaskyApp"
         android:allowBackup="true"

--- a/app/src/main/java/com/nibalk/tasky/TaskyApp.kt
+++ b/app/src/main/java/com/nibalk/tasky/TaskyApp.kt
@@ -3,6 +3,7 @@ package com.nibalk.tasky
 import android.app.Application
 import com.nibalk.tasky.auth.data.di.authDataModule
 import com.nibalk.tasky.auth.presentation.di.authViewModelModule
+import com.nibalk.tasky.core.data.di.coreDataModule
 import com.nibalk.tasky.di.appModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
@@ -24,6 +25,7 @@ class TaskyApp: Application() {
                 appModule,
                 authDataModule,
                 authViewModelModule,
+                coreDataModule
             )
         }
     }

--- a/auth/data/build.gradle.kts
+++ b/auth/data/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.tasky.android.library)
+    alias(libs.plugins.jetbrains.kotlin.serialization)
 }
 
 android {
@@ -12,6 +13,10 @@ dependencies {
     implementation(projects.core.domain)
     implementation(projects.core.data)
 
+    // Retrofit/ Okhttp for networking
+    implementation(libs.squareup.retrofit)
+    // Kotlinx Json for Serialization
+    implementation(libs.kotlinx.serialization.json)
     // Koin for DI
     implementation(libs.bundles.koin)
     // Timber for logging

--- a/auth/data/src/main/java/com/nibalk/tasky/auth/data/di/AuthDataModule.kt
+++ b/auth/data/src/main/java/com/nibalk/tasky/auth/data/di/AuthDataModule.kt
@@ -1,10 +1,12 @@
 package com.nibalk.tasky.auth.data.di
 
 import com.nibalk.tasky.auth.data.EmailAuthPatternValidator
-import com.nibalk.tasky.auth.domain.ValidateEmailUseCase
-import com.nibalk.tasky.auth.domain.ValidateNameUseCase
-import com.nibalk.tasky.auth.domain.ValidatePasswordUseCase
+import com.nibalk.tasky.auth.data.remote.AuthApi
+import com.nibalk.tasky.auth.domain.usecases.ValidateEmailUseCase
+import com.nibalk.tasky.auth.domain.usecases.ValidateNameUseCase
+import com.nibalk.tasky.auth.domain.usecases.ValidatePasswordUseCase
 import com.nibalk.tasky.auth.domain.utils.AuthPatternValidator
+import com.nibalk.tasky.core.data.networking.RetrofitFactory
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
@@ -16,4 +18,8 @@ val authDataModule = module {
     singleOf(::ValidateNameUseCase)
     singleOf(::ValidateEmailUseCase)
     singleOf(::ValidatePasswordUseCase)
+
+    single<AuthApi> {
+        get<RetrofitFactory>().build().create(AuthApi::class.java)
+    }
 }

--- a/auth/data/src/main/java/com/nibalk/tasky/auth/data/remote/AuthApi.kt
+++ b/auth/data/src/main/java/com/nibalk/tasky/auth/data/remote/AuthApi.kt
@@ -1,0 +1,14 @@
+package com.nibalk.tasky.auth.data.remote
+
+import com.nibalk.tasky.auth.data.remote.dto.RegisterRequestDto
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface AuthApi {
+
+    @POST("/register")
+    suspend fun register(
+        @Body body: RegisterRequestDto
+    ): Response<Void>
+}

--- a/auth/data/src/main/java/com/nibalk/tasky/auth/data/remote/dto/RegisterRequestDto.kt
+++ b/auth/data/src/main/java/com/nibalk/tasky/auth/data/remote/dto/RegisterRequestDto.kt
@@ -1,0 +1,14 @@
+package com.nibalk.tasky.auth.data.remote.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RegisterRequestDto(
+    @SerialName("fullName")
+    val userName: String,
+    @SerialName("email")
+    val userEmail: String,
+    @SerialName("password")
+    val userPassword: String
+)

--- a/auth/domain/src/main/java/com/nibalk/tasky/auth/domain/usecases/ValidateEmailUseCase.kt
+++ b/auth/domain/src/main/java/com/nibalk/tasky/auth/domain/usecases/ValidateEmailUseCase.kt
@@ -1,4 +1,4 @@
-package com.nibalk.tasky.auth.domain
+package com.nibalk.tasky.auth.domain.usecases
 
 import com.nibalk.tasky.auth.domain.utils.AuthPatternValidator
 

--- a/auth/domain/src/main/java/com/nibalk/tasky/auth/domain/usecases/ValidateNameUseCase.kt
+++ b/auth/domain/src/main/java/com/nibalk/tasky/auth/domain/usecases/ValidateNameUseCase.kt
@@ -1,4 +1,4 @@
-package com.nibalk.tasky.auth.domain
+package com.nibalk.tasky.auth.domain.usecases
 
 import com.nibalk.tasky.auth.domain.utils.AuthDataValidator
 

--- a/auth/domain/src/main/java/com/nibalk/tasky/auth/domain/usecases/ValidatePasswordUseCase.kt
+++ b/auth/domain/src/main/java/com/nibalk/tasky/auth/domain/usecases/ValidatePasswordUseCase.kt
@@ -1,4 +1,4 @@
-package com.nibalk.tasky.auth.domain
+package com.nibalk.tasky.auth.domain.usecases
 
 import com.nibalk.tasky.auth.domain.utils.AuthDataValidator
 import com.nibalk.tasky.auth.domain.utils.PasswordValidationState

--- a/auth/presentation/src/main/java/com/nibalk/tasky/auth/presentation/login/LoginViewModel.kt
+++ b/auth/presentation/src/main/java/com/nibalk/tasky/auth/presentation/login/LoginViewModel.kt
@@ -9,7 +9,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.nibalk.tasky.auth.domain.ValidateEmailUseCase
+import com.nibalk.tasky.auth.domain.usecases.ValidateEmailUseCase
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine

--- a/auth/presentation/src/main/java/com/nibalk/tasky/auth/presentation/register/RegisterViewModel.kt
+++ b/auth/presentation/src/main/java/com/nibalk/tasky/auth/presentation/register/RegisterViewModel.kt
@@ -9,9 +9,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.nibalk.tasky.auth.domain.ValidateEmailUseCase
-import com.nibalk.tasky.auth.domain.ValidateNameUseCase
-import com.nibalk.tasky.auth.domain.ValidatePasswordUseCase
+import com.nibalk.tasky.auth.domain.usecases.ValidateEmailUseCase
+import com.nibalk.tasky.auth.domain.usecases.ValidateNameUseCase
+import com.nibalk.tasky.auth.domain.usecases.ValidatePasswordUseCase
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.launchIn

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.jetbrains.kotlin.android) apply false
     alias(libs.plugins.jetbrains.kotlin.jvm) apply false
     alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.jetbrains.kotlin.serialization) apply false
 }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.tasky.android.library)
+    alias(libs.plugins.jetbrains.kotlin.serialization)
 }
 
 android {
@@ -10,6 +11,14 @@ dependencies {
     // Project Modules
     implementation(projects.core.domain)
 
+    // Retrofit/ Okhttp for networking
+    implementation(libs.squareup.retrofit)
+    implementation(libs.squareup.okhttp.loggiing)
+    // Kotlinx Json for Serialization
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlinx.serialization.retrofit)
+    // Koin for DI
+    implementation(libs.bundles.koin)
     // Timber for logging
     implementation(libs.timber)
 }

--- a/core/data/src/main/java/com/nibalk/tasky/core/data/di/CoreDataModule.kt
+++ b/core/data/src/main/java/com/nibalk/tasky/core/data/di/CoreDataModule.kt
@@ -1,0 +1,27 @@
+package com.nibalk.tasky.core.data.di
+
+import com.nibalk.tasky.core.data.networking.HttpClientFactory
+import com.nibalk.tasky.core.data.networking.JsonConverterFactoryProvider
+import com.nibalk.tasky.core.data.networking.RetrofitFactory
+import com.nibalk.tasky.core.data.networking.interceptors.ApiKeyInterceptor
+import com.nibalk.tasky.core.data.networking.interceptors.LoggingInterceptor
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.module
+
+val coreDataModule = module {
+    singleOf(::ApiKeyInterceptor)
+    singleOf(::LoggingInterceptor)
+    singleOf(::HttpClientFactory)
+
+    single { JsonConverterFactoryProvider }
+
+    single { HttpClientFactory(get(), get()) }
+    single {
+        get<HttpClientFactory>().build()
+    }
+
+    single { RetrofitFactory(get(), get()) }
+    single {
+        get<RetrofitFactory>().build()
+    }
+}

--- a/core/data/src/main/java/com/nibalk/tasky/core/data/networking/HttpClientFactory.kt
+++ b/core/data/src/main/java/com/nibalk/tasky/core/data/networking/HttpClientFactory.kt
@@ -1,0 +1,17 @@
+package com.nibalk.tasky.core.data.networking
+
+import com.nibalk.tasky.core.data.networking.interceptors.ApiKeyInterceptor
+import com.nibalk.tasky.core.data.networking.interceptors.LoggingInterceptor
+import okhttp3.OkHttpClient
+
+class HttpClientFactory(
+    private val apiKeyInterceptor: ApiKeyInterceptor,
+    private val loggingInterceptor: LoggingInterceptor,
+) {
+    fun build(): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor(apiKeyInterceptor)
+            .addInterceptor(loggingInterceptor)
+            .build()
+    }
+}

--- a/core/data/src/main/java/com/nibalk/tasky/core/data/networking/JsonConverterFactoryProvider.kt
+++ b/core/data/src/main/java/com/nibalk/tasky/core/data/networking/JsonConverterFactoryProvider.kt
@@ -1,0 +1,21 @@
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.nibalk.tasky.core.data.networking
+
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import retrofit2.Converter
+
+object JsonConverterFactoryProvider {
+    fun provide(): Converter.Factory {
+        val contentType = "application/json".toMediaType()
+        val json = Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+            prettyPrint =true
+        }
+        return json.asConverterFactory(contentType)
+    }
+}

--- a/core/data/src/main/java/com/nibalk/tasky/core/data/networking/RetrofitFactory.kt
+++ b/core/data/src/main/java/com/nibalk/tasky/core/data/networking/RetrofitFactory.kt
@@ -1,0 +1,20 @@
+package com.nibalk.tasky.core.data.networking
+
+import com.nibalk.tasky.core.data.BuildConfig
+import retrofit2.Retrofit
+
+class RetrofitFactory(
+    private val httpClientFactory: HttpClientFactory,
+    private val jsonConverterFactoryProvider: JsonConverterFactoryProvider,
+) {
+    fun build(): Retrofit {
+        val retrofit: Retrofit by lazy {
+            Retrofit.Builder()
+                .baseUrl(BuildConfig.BASE_URL)
+                .client(httpClientFactory.build())
+                .addConverterFactory(jsonConverterFactoryProvider.provide())
+                .build()
+        }
+        return retrofit
+    }
+}

--- a/core/data/src/main/java/com/nibalk/tasky/core/data/networking/interceptors/ApiKeyInterceptor.kt
+++ b/core/data/src/main/java/com/nibalk/tasky/core/data/networking/interceptors/ApiKeyInterceptor.kt
@@ -1,0 +1,16 @@
+package com.nibalk.tasky.core.data.networking.interceptors
+
+import com.nibalk.tasky.core.data.BuildConfig
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class ApiKeyInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain
+            .request()
+            .newBuilder()
+            .addHeader("x-api-key", BuildConfig.API_KEY)
+            .build()
+        return chain.proceed(request)
+    }
+}

--- a/core/data/src/main/java/com/nibalk/tasky/core/data/networking/interceptors/LoggingInterceptor.kt
+++ b/core/data/src/main/java/com/nibalk/tasky/core/data/networking/interceptors/LoggingInterceptor.kt
@@ -1,0 +1,19 @@
+package com.nibalk.tasky.core.data.networking.interceptors
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import okhttp3.logging.HttpLoggingInterceptor
+import timber.log.Timber
+
+
+class LoggingInterceptor : Interceptor {
+    private val logger = HttpLoggingInterceptor { message ->
+        Timber.tag("OkHttp").d(message)
+    }.apply {
+        level= HttpLoggingInterceptor.Level.BODY
+    }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        return logger.intercept(chain)
+    }
+}

--- a/core/presentation/src/main/java/com/nibalk/tasky/core/presentation/utils/ObserveAsEvents.kt
+++ b/core/presentation/src/main/java/com/nibalk/tasky/core/presentation/utils/ObserveAsEvents.kt
@@ -1,0 +1,27 @@
+package com.nibalk.tasky.core.presentation.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+
+@Composable
+fun <T> ObserveAsEvents(
+    flow: Flow<T>,
+    key1: Any? = null,
+    key2: Any? = null,
+    onEvent: (T) -> Unit
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(flow, lifecycleOwner.lifecycle, key1, key2) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            withContext(Dispatchers.Main.immediate) {
+                flow.collect(onEvent)
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,12 +17,17 @@ activityCompose = "1.9.0"
 appcompat = "1.7.0"
 desugarJdkLibs = "2.0.4"
 # Kotlin
+kotlinxRetrofit= "0.8.0"
 kotlinxSerialization = "1.6.3"
 kotlinxCoroutines = "1.8.0"
 # Koin
 koin = "3.5.3"
 # Google Libraries
 material = "1.12.0"
+# Squareup Libraries
+retrofit = "2.9.0"
+okHttp = "4.10.0"
+gson = "2.9.0"
 # Other Libraries
 junit = "4.13.2"
 timber = "5.0.1"
@@ -68,6 +73,7 @@ android-desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", vers
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 # Kotlin
+kotlinx-serialization-retrofit = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "kotlinxRetrofit"}
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization"}
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines"}
 kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinxCoroutines"}
@@ -78,6 +84,10 @@ koin-core = { group = "io.insert-koin", name = "koin-core", version.ref = "koin"
 koin-androidx-compose = { group = "io.insert-koin", name = "koin-androidx-compose", version.ref = "koin" }
 # Google Libraries
 google-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+# Squareup Libraries
+squareup-retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+squareup-okhttp-loggiing = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okHttp" }
+squareup-converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "gson" }
 # Other Libraries
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
@@ -96,6 +106,7 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinJvm" }
+jetbrains-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 
 #Convention Plugins
 tasky-android-application = { id = "nibalk.tasky.android.application", version = "unspecified" }


### PR DESCRIPTION
### Week 03 PR 02 - Register Screen Api 

**What is done
==========**

Add the data layer classes for registration flow

**What is NOT done here BUT will do in a separate PR
==========================================**

1. Replace the route with new type-safe navigation with serialize annotations
2. Suggestion of not to pass the visibility to sub-components
3. Suggestion of not to validate the email while typing

**Next Steps
==========**

Add auth repo layer for user registration

