### PR TITLE
03.03 add domain layer classes for user registration flow

### DIFF
--- a/app/src/main/java/com/nibalk/tasky/TaskyApp.kt
+++ b/app/src/main/java/com/nibalk/tasky/TaskyApp.kt
@@ -2,6 +2,7 @@ package com.nibalk.tasky
 
 import android.app.Application
 import com.nibalk.tasky.auth.data.di.authDataModule
+import com.nibalk.tasky.auth.presentation.di.authUseCaseModule
 import com.nibalk.tasky.auth.presentation.di.authViewModelModule
 import com.nibalk.tasky.core.data.di.coreDataModule
 import com.nibalk.tasky.di.appModule
@@ -24,6 +25,7 @@ class TaskyApp: Application() {
             modules(
                 appModule,
                 authDataModule,
+                authUseCaseModule,
                 authViewModelModule,
                 coreDataModule
             )

--- a/app/src/main/java/com/nibalk/tasky/navigation/NavigationRoot.kt
+++ b/app/src/main/java/com/nibalk/tasky/navigation/NavigationRoot.kt
@@ -43,7 +43,7 @@ private fun NavGraphBuilder.authGraph(navController: NavHostController) {
                     navController.navigateUp()
                 },
                 onSuccessfulRegistration = {
-                    navController.navigateUp()
+                    //navController.navigateUp()
                 }
             )
         }

--- a/auth/data/src/main/java/com/nibalk/tasky/auth/data/AuthRepositoryImpl.kt
+++ b/auth/data/src/main/java/com/nibalk/tasky/auth/data/AuthRepositoryImpl.kt
@@ -1,0 +1,30 @@
+package com.nibalk.tasky.auth.data
+
+import com.nibalk.tasky.auth.data.remote.AuthApi
+import com.nibalk.tasky.auth.data.remote.dto.RegisterRequestDto
+import com.nibalk.tasky.auth.domain.AuthRepository
+import com.nibalk.tasky.auth.domain.model.RegisterRequestParams
+import com.nibalk.tasky.core.data.networking.safeCall
+import com.nibalk.tasky.core.domain.util.DataError
+import com.nibalk.tasky.core.domain.util.EmptyResult
+import com.nibalk.tasky.core.domain.util.asEmptyDataResult
+
+class AuthRepositoryImpl(
+    private val authApi: AuthApi
+): AuthRepository {
+
+    override suspend fun register(
+        registerRequestParams: RegisterRequestParams
+    ): EmptyResult<DataError.Network> {
+        val response = safeCall {
+            authApi.register(
+                body = RegisterRequestDto(
+                    userName = registerRequestParams.name,
+                    userEmail = registerRequestParams.email,
+                    userPassword = registerRequestParams.password
+                )
+            )
+        }
+        return response.asEmptyDataResult()
+    }
+}

--- a/auth/data/src/main/java/com/nibalk/tasky/auth/data/di/AuthDataModule.kt
+++ b/auth/data/src/main/java/com/nibalk/tasky/auth/data/di/AuthDataModule.kt
@@ -1,13 +1,13 @@
 package com.nibalk.tasky.auth.data.di
 
+import com.nibalk.tasky.auth.data.AuthRepositoryImpl
 import com.nibalk.tasky.auth.data.EmailAuthPatternValidator
 import com.nibalk.tasky.auth.data.remote.AuthApi
-import com.nibalk.tasky.auth.domain.usecases.ValidateEmailUseCase
-import com.nibalk.tasky.auth.domain.usecases.ValidateNameUseCase
-import com.nibalk.tasky.auth.domain.usecases.ValidatePasswordUseCase
+import com.nibalk.tasky.auth.domain.AuthRepository
 import com.nibalk.tasky.auth.domain.utils.AuthPatternValidator
 import com.nibalk.tasky.core.data.networking.RetrofitFactory
 import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val authDataModule = module {
@@ -15,9 +15,7 @@ val authDataModule = module {
         EmailAuthPatternValidator
     }
 
-    singleOf(::ValidateNameUseCase)
-    singleOf(::ValidateEmailUseCase)
-    singleOf(::ValidatePasswordUseCase)
+    singleOf(::AuthRepositoryImpl).bind<AuthRepository>()
 
     single<AuthApi> {
         get<RetrofitFactory>().build().create(AuthApi::class.java)

--- a/auth/domain/src/main/java/com/nibalk/tasky/auth/domain/AuthRepository.kt
+++ b/auth/domain/src/main/java/com/nibalk/tasky/auth/domain/AuthRepository.kt
@@ -1,0 +1,11 @@
+package com.nibalk.tasky.auth.domain
+
+import com.nibalk.tasky.auth.domain.model.RegisterRequestParams
+import com.nibalk.tasky.core.domain.util.DataError
+import com.nibalk.tasky.core.domain.util.EmptyResult
+
+interface AuthRepository {
+    suspend fun register(
+        registerRequestParams: RegisterRequestParams
+    ): EmptyResult<DataError.Network>
+}

--- a/auth/domain/src/main/java/com/nibalk/tasky/auth/domain/model/RegisterRequestParams.kt
+++ b/auth/domain/src/main/java/com/nibalk/tasky/auth/domain/model/RegisterRequestParams.kt
@@ -1,0 +1,7 @@
+package com.nibalk.tasky.auth.domain.model
+
+data class RegisterRequestParams(
+    val name: String,
+    val email: String,
+    val password: String
+)

--- a/auth/domain/src/main/java/com/nibalk/tasky/auth/domain/usecase/RegisterUserUseCase.kt
+++ b/auth/domain/src/main/java/com/nibalk/tasky/auth/domain/usecase/RegisterUserUseCase.kt
@@ -1,0 +1,14 @@
+package com.nibalk.tasky.auth.domain.usecase
+
+import com.nibalk.tasky.auth.domain.AuthRepository
+import com.nibalk.tasky.auth.domain.model.RegisterRequestParams
+import com.nibalk.tasky.core.domain.util.DataError
+import com.nibalk.tasky.core.domain.util.Result
+
+class RegisterUserUseCase(
+    private val authRepository: AuthRepository
+) {
+    suspend operator fun invoke(registerParams: RegisterRequestParams) : Result<Unit, DataError.Network> {
+        return authRepository.register(registerParams)
+    }
+}

--- a/auth/domain/src/main/java/com/nibalk/tasky/auth/domain/usecase/ValidateEmailUseCase.kt
+++ b/auth/domain/src/main/java/com/nibalk/tasky/auth/domain/usecase/ValidateEmailUseCase.kt
@@ -1,4 +1,4 @@
-package com.nibalk.tasky.auth.domain.usecases
+package com.nibalk.tasky.auth.domain.usecase
 
 import com.nibalk.tasky.auth.domain.utils.AuthPatternValidator
 

--- a/auth/domain/src/main/java/com/nibalk/tasky/auth/domain/usecase/ValidateNameUseCase.kt
+++ b/auth/domain/src/main/java/com/nibalk/tasky/auth/domain/usecase/ValidateNameUseCase.kt
@@ -1,4 +1,4 @@
-package com.nibalk.tasky.auth.domain.usecases
+package com.nibalk.tasky.auth.domain.usecase
 
 import com.nibalk.tasky.auth.domain.utils.AuthDataValidator
 

--- a/auth/domain/src/main/java/com/nibalk/tasky/auth/domain/usecase/ValidatePasswordUseCase.kt
+++ b/auth/domain/src/main/java/com/nibalk/tasky/auth/domain/usecase/ValidatePasswordUseCase.kt
@@ -1,4 +1,4 @@
-package com.nibalk.tasky.auth.domain.usecases
+package com.nibalk.tasky.auth.domain.usecase
 
 import com.nibalk.tasky.auth.domain.utils.AuthDataValidator
 import com.nibalk.tasky.auth.domain.utils.PasswordValidationState

--- a/auth/presentation/src/main/java/com/nibalk/tasky/auth/presentation/di/AuthViewModelModule.kt
+++ b/auth/presentation/src/main/java/com/nibalk/tasky/auth/presentation/di/AuthViewModelModule.kt
@@ -1,11 +1,25 @@
 package com.nibalk.tasky.auth.presentation.di
 
+import com.nibalk.tasky.auth.domain.usecase.RegisterUserUseCase
+import com.nibalk.tasky.auth.domain.usecase.ValidateEmailUseCase
+import com.nibalk.tasky.auth.domain.usecase.ValidateNameUseCase
+import com.nibalk.tasky.auth.domain.usecase.ValidatePasswordUseCase
 import com.nibalk.tasky.auth.presentation.login.LoginViewModel
 import com.nibalk.tasky.auth.presentation.register.RegisterViewModel
 import org.koin.androidx.viewmodel.dsl.viewModelOf
+import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
+
+val authUseCaseModule = module {
+    singleOf(::ValidateNameUseCase)
+    singleOf(::ValidateEmailUseCase)
+    singleOf(::ValidatePasswordUseCase)
+    singleOf(::RegisterUserUseCase)
+}
 
 val authViewModelModule = module {
     viewModelOf(::RegisterViewModel)
     viewModelOf(::LoginViewModel)
 }
+
+

--- a/auth/presentation/src/main/java/com/nibalk/tasky/auth/presentation/login/LoginViewModel.kt
+++ b/auth/presentation/src/main/java/com/nibalk/tasky/auth/presentation/login/LoginViewModel.kt
@@ -9,7 +9,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.nibalk.tasky.auth.domain.usecases.ValidateEmailUseCase
+import com.nibalk.tasky.auth.domain.usecase.ValidateEmailUseCase
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine

--- a/auth/presentation/src/main/java/com/nibalk/tasky/auth/presentation/register/RegisterEvent.kt
+++ b/auth/presentation/src/main/java/com/nibalk/tasky/auth/presentation/register/RegisterEvent.kt
@@ -4,5 +4,5 @@ import com.nibalk.tasky.core.presentation.utils.UiText
 
 sealed interface RegisterEvent {
     data object RegistrationSuccess: RegisterEvent
-    data class Error(val error: UiText): RegisterEvent
+    data class RegistrationError(val error: UiText): RegisterEvent
 }

--- a/auth/presentation/src/main/java/com/nibalk/tasky/auth/presentation/register/RegisterScreen.kt
+++ b/auth/presentation/src/main/java/com/nibalk/tasky/auth/presentation/register/RegisterScreen.kt
@@ -1,6 +1,7 @@
 @file:OptIn(ExperimentalFoundationApi::class)
 package com.nibalk.tasky.auth.presentation.register
 
+import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -15,7 +16,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
@@ -30,6 +33,7 @@ import com.nibalk.tasky.core.presentation.components.TaskyTextField
 import com.nibalk.tasky.core.presentation.themes.CheckMarkIcon
 import com.nibalk.tasky.core.presentation.themes.TaskyTheme
 import com.nibalk.tasky.core.presentation.themes.spacing
+import com.nibalk.tasky.core.presentation.utils.ObserveAsEvents
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -38,6 +42,30 @@ fun RegisterScreenRoot(
     onSuccessfulRegistration: () -> Unit,
     viewModel: RegisterViewModel = koinViewModel(),
 ) {
+    val context = LocalContext.current
+    val keyboardController = LocalSoftwareKeyboardController.current
+    ObserveAsEvents(viewModel.uiEvent) { event ->
+        when(event) {
+            is RegisterEvent.RegistrationError -> {
+                keyboardController?.hide()
+                Toast.makeText(
+                    context,
+                    event.error.asString(context),
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+            RegisterEvent.RegistrationSuccess -> {
+                keyboardController?.hide()
+                Toast.makeText(
+                    context,
+                    R.string.auth_is_successful,
+                    Toast.LENGTH_LONG
+                ).show()
+                onSuccessfulRegistration()
+            }
+        }
+    }
+
     RegisterScreen(
         state = viewModel.state,
         onAction = { action ->

--- a/auth/presentation/src/main/res/values/strings.xml
+++ b/auth/presentation/src/main/res/values/strings.xml
@@ -15,5 +15,7 @@
     <string name="auth_at_least_one_number">At least one number</string>
     <string name="auth_at_least_one_lowercase_char">At least one lowercase character</string>
     <string name="auth_at_least_one_uppercase_char">At least one uppercase character</string>
+    <string name="auth_error_email_exists">A user with that email already exists.</string>
+    <string name="auth_is_successful">Registration successful! You can log in now.</string>
 
 </resources>

--- a/core/data/src/main/java/com/nibalk/tasky/core/data/di/CoreDataModule.kt
+++ b/core/data/src/main/java/com/nibalk/tasky/core/data/di/CoreDataModule.kt
@@ -11,17 +11,9 @@ import org.koin.dsl.module
 val coreDataModule = module {
     singleOf(::ApiKeyInterceptor)
     singleOf(::LoggingInterceptor)
-    singleOf(::HttpClientFactory)
 
     single { JsonConverterFactoryProvider }
 
-    single { HttpClientFactory(get(), get()) }
-    single {
-        get<HttpClientFactory>().build()
-    }
-
-    single { RetrofitFactory(get(), get()) }
-    single {
-        get<RetrofitFactory>().build()
-    }
+    singleOf(::HttpClientFactory)
+    singleOf(::RetrofitFactory)
 }

--- a/core/data/src/main/java/com/nibalk/tasky/core/data/networking/HttpClientExt.kt
+++ b/core/data/src/main/java/com/nibalk/tasky/core/data/networking/HttpClientExt.kt
@@ -1,0 +1,40 @@
+package com.nibalk.tasky.core.data.networking
+
+import com.nibalk.tasky.core.domain.util.DataError
+import com.nibalk.tasky.core.domain.util.Result
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.SerializationException
+import retrofit2.Response
+import java.nio.channels.UnresolvedAddressException
+
+
+inline fun <reified T> safeCall(execute: () -> Response<T>): Result<T?, DataError.Network> {
+    val response = try {
+        execute()
+    } catch(e: UnresolvedAddressException) {
+        e.printStackTrace()
+        return Result.Error(DataError.Network.NO_INTERNET)
+    } catch (e: SerializationException) {
+        e.printStackTrace()
+        return Result.Error(DataError.Network.SERIALIZATION)
+    } catch(e: Exception) {
+        if(e is CancellationException) throw e
+        e.printStackTrace()
+        return Result.Error(DataError.Network.UNKNOWN)
+    }
+
+    return responseToResult(response)
+}
+
+inline fun <reified T> responseToResult(response: Response<T>): Result<T?, DataError.Network> {
+    return when(response.code()) {
+        in 200..299 -> Result.Success(response.body())
+        401 -> Result.Error(DataError.Network.UNAUTHORIZED)
+        408 -> Result.Error(DataError.Network.REQUEST_TIMEOUT)
+        409 -> Result.Error(DataError.Network.CONFLICT)
+        413 -> Result.Error(DataError.Network.PAYLOAD_TOO_LARGE)
+        429 -> Result.Error(DataError.Network.TOO_MANY_REQUESTS)
+        in 500..599 -> Result.Error(DataError.Network.SERVER_ERROR)
+        else -> Result.Error(DataError.Network.UNKNOWN)
+    }
+}

--- a/core/domain/src/main/java/com/nibalk/tasky/core/domain/util/DataError.kt
+++ b/core/domain/src/main/java/com/nibalk/tasky/core/domain/util/DataError.kt
@@ -1,0 +1,19 @@
+package com.nibalk.tasky.core.domain.util
+
+sealed interface DataError: BaseError {
+    enum class Network: DataError {
+        REQUEST_TIMEOUT,
+        UNAUTHORIZED,
+        CONFLICT,
+        TOO_MANY_REQUESTS,
+        NO_INTERNET,
+        PAYLOAD_TOO_LARGE,
+        SERVER_ERROR,
+        SERIALIZATION,
+        UNKNOWN
+    }
+
+    enum class Local: DataError {
+        DISK_FULL
+    }
+}

--- a/core/domain/src/main/java/com/nibalk/tasky/core/domain/util/Error.kt
+++ b/core/domain/src/main/java/com/nibalk/tasky/core/domain/util/Error.kt
@@ -1,0 +1,3 @@
+package com.nibalk.tasky.core.domain.util
+
+interface BaseError

--- a/core/domain/src/main/java/com/nibalk/tasky/core/domain/util/Result.kt
+++ b/core/domain/src/main/java/com/nibalk/tasky/core/domain/util/Result.kt
@@ -1,0 +1,38 @@
+package com.nibalk.tasky.core.domain.util
+
+sealed interface Result<out D, out E: BaseError> {
+    data class Success<out D>(val data: D): Result<D, Nothing>
+    data class Error<out E: BaseError>(val error: E): Result<Nothing, E>
+}
+
+inline fun <T, E: BaseError> Result<T, E>.onSuccess(action: (T) -> Unit): Result<T, E> {
+    return when(this) {
+        is Result.Error -> this
+        is Result.Success -> {
+            action(data)
+            this
+        }
+    }
+}
+inline fun <T, E: BaseError> Result<T, E>.onError(action: (E) -> Unit): Result<T, E> {
+    return when(this) {
+        is Result.Error -> {
+            action(error)
+            this
+        }
+        is Result.Success -> this
+    }
+}
+
+inline fun <T, E: BaseError, R> Result<T, E>.map(map: (T) -> R): Result<R, E> {
+    return when(this) {
+        is Result.Error -> Result.Error(error)
+        is Result.Success -> Result.Success(map(data))
+    }
+}
+
+fun <T, E: BaseError> Result<T, E>.asEmptyDataResult(): EmptyResult<E> {
+    return map {  }
+}
+
+typealias EmptyResult<E> = Result<Unit, E>

--- a/core/presentation/src/main/java/com/nibalk/tasky/core/presentation/components/TaskyActionButton.kt
+++ b/core/presentation/src/main/java/com/nibalk/tasky/core/presentation/components/TaskyActionButton.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.nibalk.tasky.core.presentation.themes.TaskyTheme
+import com.nibalk.tasky.core.presentation.themes.TaskyWhite
 import com.nibalk.tasky.core.presentation.themes.spacing
 
 @Composable
@@ -61,7 +62,7 @@ fun TaskyActionButton(
                     .size(15.dp)
                     .alpha(if (isLoading) 1f else 0f),
                 strokeWidth = 1.5.dp,
-                color = MaterialTheme.colorScheme.onPrimary
+                color = TaskyWhite
             )
         }
     }

--- a/core/presentation/src/main/java/com/nibalk/tasky/core/presentation/utils/DataErrorToText.kt
+++ b/core/presentation/src/main/java/com/nibalk/tasky/core/presentation/utils/DataErrorToText.kt
@@ -1,0 +1,31 @@
+package com.nibalk.tasky.core.presentation.utils
+
+import com.nibalk.tasky.core.domain.util.DataError
+import com.nibalk.tasky.core.presentation.R
+
+fun DataError.asUiText(): UiText {
+    return when(this) {
+        DataError.Local.DISK_FULL -> UiText.StringResource(
+            R.string.error_disk_full
+        )
+        DataError.Network.REQUEST_TIMEOUT -> UiText.StringResource(
+            R.string.error_request_timeout
+        )
+        DataError.Network.TOO_MANY_REQUESTS -> UiText.StringResource(
+            R.string.error_too_many_requests
+        )
+        DataError.Network.NO_INTERNET -> UiText.StringResource(
+            R.string.error_no_internet
+        )
+        DataError.Network.PAYLOAD_TOO_LARGE -> UiText.StringResource(
+            R.string.error_payload_too_large
+        )
+        DataError.Network.SERVER_ERROR -> UiText.StringResource(
+            R.string.error_server_error
+        )
+        DataError.Network.SERIALIZATION -> UiText.StringResource(
+            R.string.error_serialization
+        )
+        else -> UiText.StringResource(R.string.error_unknown)
+    }
+}

--- a/core/presentation/src/main/res/values/strings.xml
+++ b/core/presentation/src/main/res/values/strings.xml
@@ -3,4 +3,14 @@
     <string name="content_description_back">Back</string>
     <string name="content_description_show_password_text">Show Password</string>
     <string name="content_description_hide_password_text">Hide password</string>
+
+    <!-- Error Messages -->
+    <string name="error_disk_full">Failed to save the item because your disk is full.</string>
+    <string name="error_request_timeout">The request timed out.</string>
+    <string name="error_too_many_requests">You\'ve hit your rate limit.</string>
+    <string name="error_no_internet">Couldn\'t reach server, please check your connection.</string>
+    <string name="error_payload_too_large">The file you\'re trying to upload is too large.</string>
+    <string name="error_server_error">Oops, something went wrong, please try again.</string>
+    <string name="error_serialization">Oops, couldn\'t parse data.</string>
+    <string name="error_unknown">An unknown error occurred.</string>
 </resources>


### PR DESCRIPTION
### Week 03 PR 03 - Register Screen Domain

**What is done
==========**

Add the domain layer classes for registration flow
Finish the registration flow backend integration

**What is NOT done here BUT will do in a separate PR
==========================================**

Replace the route with new type-safe navigation with serialize annotations
Suggestion of not to pass the visibility to sub-components
Suggestion of not to validate the email while typing

**Next Steps
==========**

Add session storage