### PR TITLE
06.03 remaining changes in agenda screen

### DIFF
--- a/agenda/presentation/src/main/java/com/nibalk/tasky/agenda/presentation/components/AgendaCard.kt
+++ b/agenda/presentation/src/main/java/com/nibalk/tasky/agenda/presentation/components/AgendaCard.kt
@@ -9,12 +9,8 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,7 +18,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -147,19 +142,12 @@ private fun AgendaCardHeader(
             Spacer(modifier = Modifier.width(MaterialTheme.spacing.spaceMedium))
         }
         // Title Row - More Options
-        IconButton(
-            onClick = {},
+        AgendaCardMoreOptions(
             modifier = Modifier
                 .weight(1f),
-        ) {
-            Icon(
-                modifier = Modifier.rotate(90.0f),
-                imageVector = Icons.Outlined.MoreVert,
-                contentDescription = "options",
-                tint = agendaType.contentColor
-            )
-        }
-
+            contentColor = agendaType.contentColor,
+            onMenuItemClicked = onOptionsClick,
+        )
     }
 }
 

--- a/agenda/presentation/src/main/java/com/nibalk/tasky/agenda/presentation/components/AgendaCard.kt
+++ b/agenda/presentation/src/main/java/com/nibalk/tasky/agenda/presentation/components/AgendaCard.kt
@@ -83,7 +83,7 @@ fun AgendaCard(
             modifier = Modifier
                 .align(Alignment.Start)
                 .padding(
-                    start = MaterialTheme.spacing.spaceExtraLarge,
+                    start = 56.dp,
                     end = MaterialTheme.spacing.spaceExtraLarge,
                     bottom = MaterialTheme.spacing.spaceMedium,
                 )

--- a/agenda/presentation/src/main/java/com/nibalk/tasky/agenda/presentation/components/AgendaCardMoreOptions.kt
+++ b/agenda/presentation/src/main/java/com/nibalk/tasky/agenda/presentation/components/AgendaCardMoreOptions.kt
@@ -1,0 +1,91 @@
+package com.nibalk.tasky.agenda.presentation.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.MoreVert
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.nibalk.tasky.agenda.presentation.model.AgendaItemActionType
+import com.nibalk.tasky.core.presentation.components.TaskyDropDownMenu
+import com.nibalk.tasky.core.presentation.components.TaskyDropDownMenuItem
+import com.nibalk.tasky.core.presentation.themes.TaskyDarkGray
+import com.nibalk.tasky.core.presentation.themes.TaskyTheme
+
+@Composable
+fun AgendaCardMoreOptions(
+    modifier: Modifier = Modifier,
+    contentColor: Color,
+    onMenuItemClicked: (AgendaItemActionType) -> Unit,
+) {
+    var isMoreMenuShown by remember {
+        mutableStateOf(false)
+    }
+
+    Box(
+        modifier = modifier
+    ) {
+        IconButton(
+            onClick = {
+                isMoreMenuShown = true
+            },
+        ) {
+            Icon(
+                modifier = Modifier.rotate(90.0f),
+                imageVector = Icons.Outlined.MoreVert,
+                contentDescription = "options",
+                tint = contentColor
+            )
+        }
+        TaskyDropDownMenu(
+            isMenuShown = isMoreMenuShown,
+            onDismissRequest = { isMoreMenuShown = false },
+            menuItems = listOf(
+                TaskyDropDownMenuItem(
+                    displayText = stringResource(id = AgendaItemActionType.OPEN.menuNameResId),
+                    leadingIcon = AgendaItemActionType.OPEN.menuIconResId,
+                    onClick = {
+                        onMenuItemClicked(AgendaItemActionType.OPEN)
+                        isMoreMenuShown = false
+                    }
+                ),
+                TaskyDropDownMenuItem(
+                    displayText = stringResource(id = AgendaItemActionType.EDIT.menuNameResId),
+                    leadingIcon = AgendaItemActionType.EDIT.menuIconResId,
+                    onClick = {
+                        onMenuItemClicked(AgendaItemActionType.EDIT)
+                        isMoreMenuShown = false
+                    }
+                ),
+                TaskyDropDownMenuItem(
+                    displayText = stringResource(id = AgendaItemActionType.DELETE.menuNameResId),
+                    leadingIcon = AgendaItemActionType.DELETE.menuIconResId,
+                    onClick = {
+                        onMenuItemClicked(AgendaItemActionType.DELETE)
+                        isMoreMenuShown = false
+                    }
+                ),
+            )
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun AgendaCardMoreOptionsPreview() {
+    TaskyTheme {
+        AgendaCardMoreOptions(
+            contentColor = TaskyDarkGray,
+            onMenuItemClicked = {}
+        )
+    }
+}

--- a/agenda/presentation/src/main/java/com/nibalk/tasky/agenda/presentation/components/AgendaHeader.kt
+++ b/agenda/presentation/src/main/java/com/nibalk/tasky/agenda/presentation/components/AgendaHeader.kt
@@ -57,7 +57,7 @@ private fun AgendaHeaderPreview() {
     TaskyTheme {
         AgendaHeader(
             selectedDate = LocalDate.now(),
-            userInitials = "NI",
+            userInitials = "AB",
             onDayClicked = {},
             onLogoutClicked = {}
         )

--- a/agenda/presentation/src/main/java/com/nibalk/tasky/agenda/presentation/components/AgendaRefreshableList.kt
+++ b/agenda/presentation/src/main/java/com/nibalk/tasky/agenda/presentation/components/AgendaRefreshableList.kt
@@ -29,12 +29,13 @@ import com.nibalk.tasky.core.presentation.themes.spacing
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun <T> AgendaRefreshableList(
+    modifier: Modifier = Modifier,
+    lazyListState: LazyListState = rememberLazyListState(),
     items: List<T>,
-    content: @Composable (T) -> Unit,
     isRefreshing: Boolean,
     onRefresh: () -> Unit,
-    modifier: Modifier = Modifier,
-    lazyListState: LazyListState = rememberLazyListState()
+    emptyContent: @Composable () -> Unit,
+    listContent: @Composable (T) -> Unit,
 ) {
 
     // val pullToRefreshState = rememberPullToRefreshState()
@@ -82,14 +83,13 @@ fun <T> AgendaRefreshableList(
                 state = lazyListState,
                 contentPadding = PaddingValues(0.dp),
             ) {
+                if (items.isEmpty()) {
+                    item {
+                        emptyContent()
+                    }
+                }
                 items(items.size) { index  ->
-                    content(items[index])
-//                    Box(
-//                        modifier = Modifier
-//                            .padding(vertical = MaterialTheme.spacing.spaceSmall)
-//                    ) {
-//                        content(items[index])
-//                    }
+                    listContent(items[index])
                 }
             }
         }
@@ -102,12 +102,13 @@ fun AgendaRefreshableListPreview() {
     TaskyTheme {
         AgendaRefreshableList(
             items = (1..100).map { "Item $it" },
-            content = { itemTitle ->
+            isRefreshing = false,
+            listContent = { itemTitle ->
                 Text(
                     text = itemTitle,
                 )
             },
-            isRefreshing = false,
+            emptyContent = {},
             onRefresh = {}
         )
     }

--- a/agenda/presentation/src/main/java/com/nibalk/tasky/agenda/presentation/components/AgendaRefreshableList.kt
+++ b/agenda/presentation/src/main/java/com/nibalk/tasky/agenda/presentation/components/AgendaRefreshableList.kt
@@ -83,12 +83,13 @@ fun <T> AgendaRefreshableList(
                 contentPadding = PaddingValues(0.dp),
             ) {
                 items(items.size) { index  ->
-                    Box(
-                        modifier = Modifier
-                            .padding(vertical = MaterialTheme.spacing.spaceSmall)
-                    ) {
-                        content(items[index])
-                    }
+                    content(items[index])
+//                    Box(
+//                        modifier = Modifier
+//                            .padding(vertical = MaterialTheme.spacing.spaceSmall)
+//                    ) {
+//                        content(items[index])
+//                    }
                 }
             }
         }

--- a/agenda/presentation/src/main/java/com/nibalk/tasky/agenda/presentation/home/HomeAction.kt
+++ b/agenda/presentation/src/main/java/com/nibalk/tasky/agenda/presentation/home/HomeAction.kt
@@ -12,15 +12,15 @@ sealed interface HomeAction {
     data object OnAgendaListRefreshed: HomeAction
     data class OnAddAgendaOptionsClicked(val agendaType: AgendaType) : HomeAction
     // List Item
-    data class OnListItemOptionOpenClick(
+    data class OnListItemOptionOpenClicked(
         val agendaItem: AgendaItem,
         val agendaType: AgendaType
     ) : HomeAction
-    data class OnListItemOptionEditClick(
+    data class OnListItemOptionEditClicked(
         val agendaItem: AgendaItem,
         val agendaType: AgendaType
     ) : HomeAction
-    data class OnListItemOptionDeleteClick(
+    data class OnListItemOptionDeleteClicked(
         val agendaItem: AgendaItem,
         val agendaType: AgendaType
     ) : HomeAction

--- a/agenda/presentation/src/main/java/com/nibalk/tasky/agenda/presentation/home/HomeScreen.kt
+++ b/agenda/presentation/src/main/java/com/nibalk/tasky/agenda/presentation/home/HomeScreen.kt
@@ -2,15 +2,21 @@ package com.nibalk.tasky.agenda.presentation.home
 
 import android.annotation.SuppressLint
 import android.widget.Toast
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.material3.FabPosition
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
@@ -26,9 +32,15 @@ import com.nibalk.tasky.agenda.presentation.model.AgendaItemActionType
 import com.nibalk.tasky.agenda.presentation.model.AgendaType
 import com.nibalk.tasky.agenda.presentation.utils.getSurroundingDays
 import com.nibalk.tasky.core.presentation.components.TaskyBackground
+import com.nibalk.tasky.core.presentation.components.TaskyNeedleSeparator
 import com.nibalk.tasky.core.presentation.themes.TaskyTheme
+import com.nibalk.tasky.core.presentation.themes.spacing
 import com.nibalk.tasky.core.presentation.utils.ObserveAsEvents
 import org.koin.androidx.compose.koinViewModel
+import timber.log.Timber
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import com.nibalk.tasky.core.presentation.R as CoreR
 
 typealias IsDetailScreenEditable = Boolean
@@ -46,7 +58,7 @@ fun HomeScreenRoot(
                 Toast.makeText(context, event.error.asString(context), Toast.LENGTH_LONG).show()
             }
             is HomeEvent.FetchAgendaSuccess -> {
-                Toast.makeText(context, R.string.agenda_items_list_loaded, Toast.LENGTH_SHORT).show()
+                //Toast.makeText(context, R.string.agenda_items_list_loaded, Toast.LENGTH_SHORT).show()
             }
             is HomeEvent.LogoutError -> {
                 Toast.makeText(context, event.error.asString(context), Toast.LENGTH_LONG).show()
@@ -85,12 +97,16 @@ fun HomeScreenRoot(
     )
 }
 
+
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun HomeScreen(
     state: HomeState,
     onAction: (HomeAction) -> Unit
 ) {
+    val now = LocalDateTime.now()
+    var showedNeedleOnce = false
+
     Scaffold(
         floatingActionButtonPosition = FabPosition.End,
         floatingActionButton = {
@@ -127,32 +143,24 @@ fun HomeScreen(
                         onAction(HomeAction.OnDayClicked(clickedDate))
                     }
                 )
+                AgendaListDateTitle(
+                    selectedDate = state.selectedDate,
+                    currentDate = state.currentDate
+                )
                 AgendaRefreshableList(
                     modifier = Modifier.fillMaxWidth(),
                     items = state.agendaItems,
-                    content = { item ->
-                        val agendaType: AgendaType = when (item) {
-                            is AgendaItem.Task -> AgendaType.TASK
-                            is AgendaItem.Event -> AgendaType.EVENT
-                            is AgendaItem.Reminder -> AgendaType.REMINDER
-                        }
-                        AgendaCard(
-                            item = item,
-                            agendaType = agendaType,
-                            onItemClick = {},
-                            onIsDone = {}
-                        ) { actionType ->
-                            when(actionType) {
-                                AgendaItemActionType.OPEN -> {
-                                    onAction(HomeAction.OnListItemOptionOpenClicked(item, agendaType))
-                                }
-                                AgendaItemActionType.EDIT -> {
-                                    onAction(HomeAction.OnListItemOptionEditClicked(item, agendaType))
-                                }
-                                AgendaItemActionType.DELETE -> {
-                                    onAction(HomeAction.OnListItemOptionDeleteClicked(item, agendaType))
-                                }
-                            }
+                    content = { agendaItem ->
+                        val shouldShowNeedle =
+                            (agendaItem.startAt.isEqual(now) || agendaItem.startAt.isAfter(now))
+                        AgendaListItemCard(
+                            item = agendaItem,
+                            showNeedle = shouldShowNeedle,
+                            showedNeedleOnce = showedNeedleOnce,
+                            onAction = onAction
+                        )
+                        if (shouldShowNeedle && !showedNeedleOnce) {
+                            showedNeedleOnce = true
                         }
                     },
                     isRefreshing = state.isLoading,
@@ -189,4 +197,70 @@ private fun HomeScreenPreviewScreenSizes() {
             onAction = {}
         )
     }
+}
+
+@Composable
+private fun AgendaListItemCard(
+    item: AgendaItem,
+    showNeedle: Boolean,
+    showedNeedleOnce: Boolean,
+    onAction: (HomeAction) -> Unit,
+) {
+    val agendaType: AgendaType = when (item) {
+        is AgendaItem.Task -> AgendaType.TASK
+        is AgendaItem.Event -> AgendaType.EVENT
+        is AgendaItem.Reminder -> AgendaType.REMINDER
+    }
+    AgendaCard(
+        item = item,
+        agendaType = agendaType,
+        onItemClick = {},
+        onIsDone = {}
+    ) { actionType ->
+        when(actionType) {
+            AgendaItemActionType.OPEN -> {
+                onAction(HomeAction.OnListItemOptionOpenClicked(item, agendaType))
+            }
+            AgendaItemActionType.EDIT -> {
+                onAction(HomeAction.OnListItemOptionEditClicked(item, agendaType))
+            }
+            AgendaItemActionType.DELETE -> {
+                onAction(HomeAction.OnListItemOptionDeleteClicked(item, agendaType))
+            }
+        }
+    }
+    Box(
+        modifier = Modifier
+            .padding(vertical = MaterialTheme.spacing.spaceSmall),
+        contentAlignment = Alignment.Center
+    ) {
+        Timber.tag("Needle").d("${item.id} -> showNeedle = $showNeedle and showedNeedleOnce = $showedNeedleOnce")
+        if (showNeedle && !showedNeedleOnce) {
+            TaskyNeedleSeparator(
+                modifier = Modifier
+                    .align(Alignment.Center),
+            )
+        }
+    }
+}
+
+@Composable
+private fun AgendaListDateTitle(
+    modifier: Modifier = Modifier,
+    selectedDate: LocalDate,
+    currentDate: LocalDate,
+    datePattern: String = "dd MMM yyyy",
+) {
+    Text(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = MaterialTheme.spacing.spaceLarge),
+        style = MaterialTheme.typography.headlineMedium,
+        color = MaterialTheme.colorScheme.onPrimary,
+        text =  if (selectedDate == currentDate) {
+            stringResource(R.string.agenda_title_today)
+        } else {
+            selectedDate.format(DateTimeFormatter.ofPattern(datePattern))
+        },
+    )
 }

--- a/agenda/presentation/src/main/java/com/nibalk/tasky/agenda/presentation/home/HomeScreen.kt
+++ b/agenda/presentation/src/main/java/com/nibalk/tasky/agenda/presentation/home/HomeScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
@@ -32,12 +33,12 @@ import com.nibalk.tasky.agenda.presentation.model.AgendaItemActionType
 import com.nibalk.tasky.agenda.presentation.model.AgendaType
 import com.nibalk.tasky.agenda.presentation.utils.getSurroundingDays
 import com.nibalk.tasky.core.presentation.components.TaskyBackground
+import com.nibalk.tasky.core.presentation.components.TaskyEmptyList
 import com.nibalk.tasky.core.presentation.components.TaskyNeedleSeparator
 import com.nibalk.tasky.core.presentation.themes.TaskyTheme
 import com.nibalk.tasky.core.presentation.themes.spacing
 import com.nibalk.tasky.core.presentation.utils.ObserveAsEvents
 import org.koin.androidx.compose.koinViewModel
-import timber.log.Timber
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -58,7 +59,7 @@ fun HomeScreenRoot(
                 Toast.makeText(context, event.error.asString(context), Toast.LENGTH_LONG).show()
             }
             is HomeEvent.FetchAgendaSuccess -> {
-                //Toast.makeText(context, R.string.agenda_items_list_loaded, Toast.LENGTH_SHORT).show()
+                Toast.makeText(context, R.string.agenda_items_list_loaded, Toast.LENGTH_SHORT).show()
             }
             is HomeEvent.LogoutError -> {
                 Toast.makeText(context, event.error.asString(context), Toast.LENGTH_LONG).show()
@@ -150,24 +151,31 @@ fun HomeScreen(
                 AgendaRefreshableList(
                     modifier = Modifier.fillMaxWidth(),
                     items = state.agendaItems,
-                    content = { agendaItem ->
-                        val shouldShowNeedle =
-                            (agendaItem.startAt.isEqual(now) || agendaItem.startAt.isAfter(now))
-                        AgendaListItemCard(
-                            item = agendaItem,
-                            showNeedle = shouldShowNeedle,
-                            showedNeedleOnce = showedNeedleOnce,
-                            onAction = onAction
-                        )
-                        if (shouldShowNeedle && !showedNeedleOnce) {
-                            showedNeedleOnce = true
-                        }
-                    },
                     isRefreshing = state.isLoading,
                     onRefresh = {
                         onAction(HomeAction.OnAgendaListRefreshed)
+                    },
+                    emptyContent = {
+                        TaskyEmptyList(
+                            modifier = Modifier.fillMaxSize(),
+                            displayIcon = painterResource(id = android.R.drawable.ic_menu_agenda),
+                            displayMessage = stringResource(id = R.string.agenda_empty_list),
+                            contentColor = MaterialTheme.colorScheme.onTertiary
+                        )
                     }
-                )
+                ) { agendaItem ->
+                    val shouldShowNeedle =
+                        (agendaItem.startAt.isEqual(now) || agendaItem.startAt.isAfter(now))
+                    AgendaListItemCard(
+                        item = agendaItem,
+                        showNeedle = shouldShowNeedle,
+                        showedNeedleOnce = showedNeedleOnce,
+                        onAction = onAction
+                    )
+                    if (shouldShowNeedle && !showedNeedleOnce) {
+                        showedNeedleOnce = true
+                    }
+                }
             }
         }
     }
@@ -234,7 +242,6 @@ private fun AgendaListItemCard(
             .padding(vertical = MaterialTheme.spacing.spaceSmall),
         contentAlignment = Alignment.Center
     ) {
-        Timber.tag("Needle").d("${item.id} -> showNeedle = $showNeedle and showedNeedleOnce = $showedNeedleOnce")
         if (showNeedle && !showedNeedleOnce) {
             TaskyNeedleSeparator(
                 modifier = Modifier

--- a/agenda/presentation/src/main/java/com/nibalk/tasky/agenda/presentation/home/HomeViewModel.kt
+++ b/agenda/presentation/src/main/java/com/nibalk/tasky/agenda/presentation/home/HomeViewModel.kt
@@ -14,6 +14,7 @@ import com.nibalk.tasky.core.domain.util.onSuccess
 import com.nibalk.tasky.core.presentation.utils.asUiText
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
@@ -35,7 +36,7 @@ class HomeViewModel(
             setProfileInitials()
             snapshotFlow { state.selectedDate }
                 .distinctUntilChanged()
-                .collect {
+                .collectLatest {
                     fetchAgendaItems()
                 }
         }

--- a/agenda/presentation/src/main/res/values/strings.xml
+++ b/agenda/presentation/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="agenda_items_list_loaded">Agenda items loaded</string>
     <string name="agenda_logout_successful">User logout done</string>
     <string name="agenda_title_today">Today</string>
+    <string name="agenda_empty_list">No agendas for this date.</string>
 
     <!-- Agenda Screen - Menu Options -->
     <string name="agenda_option_event">Event</string>

--- a/agenda/presentation/src/main/res/values/strings.xml
+++ b/agenda/presentation/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="agenda_dialog_confirm">Confirm</string>
     <string name="agenda_items_list_loaded">Agenda items loaded</string>
     <string name="agenda_logout_successful">User logout done</string>
+    <string name="agenda_title_today">Today</string>
 
     <!-- Agenda Screen - Menu Options -->
     <string name="agenda_option_event">Event</string>

--- a/app/src/main/java/com/nibalk/tasky/navigation/NavigationRoot.kt
+++ b/app/src/main/java/com/nibalk/tasky/navigation/NavigationRoot.kt
@@ -1,12 +1,20 @@
 package com.nibalk.tasky.navigation
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
+import androidx.navigation.toRoute
 import com.nibalk.tasky.agenda.presentation.home.HomeScreenRoot
+import com.nibalk.tasky.agenda.presentation.model.AgendaType
 import com.nibalk.tasky.auth.presentation.login.LoginScreenRoot
 import com.nibalk.tasky.auth.presentation.register.RegisterScreenRoot
 
@@ -73,8 +81,59 @@ private fun NavGraphBuilder.agendaGraph(navController: NavHostController) {
     ) {
         composable<AgendaHomeScreen> {
             HomeScreenRoot(
-                onDetailClicked = {}
+                onDetailClicked = { isEditable, agendaType, agendaItem ->
+                    when(agendaType) {
+                        AgendaType.EVENT -> navController.navigate(
+                            AgendaEventScreen(
+                                isEditable = isEditable,
+                                agendaId = agendaItem?.id
+                            )
+                        )
+                        AgendaType.TASK -> navController.navigate(
+                            AgendaTaskScreen(
+                                isEditable = isEditable,
+                                agendaId = agendaItem?.id
+                            )
+                        )
+                        AgendaType.REMINDER -> navController.navigate(
+                            AgendaReminderScreen(
+                                isEditable = isEditable,
+                                agendaId = agendaItem?.id
+                            )
+                        )
+                    }
+                }
             )
+        }
+        composable<AgendaEventScreen> { backStackEntry ->
+            val args = backStackEntry.toRoute<AgendaEventScreen>()
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text("Event Screen with ID: ${args.agendaId} and Screen Editable: ${args.isEditable}")
+            }
+        }
+        composable<AgendaTaskScreen> { backStackEntry ->
+            val args = backStackEntry.toRoute<AgendaTaskScreen>()
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text("Task Screen with ID: ${args.agendaId} and Screen Editable: ${args.isEditable}")
+            }
+        }
+        composable<AgendaReminderScreen> { backStackEntry ->
+            val args = backStackEntry.toRoute<AgendaReminderScreen>()
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text("Reminder Screen with ID: ${args.agendaId} and Screen Editable: ${args.isEditable}")
+            }
         }
     }
 }

--- a/app/src/main/java/com/nibalk/tasky/navigation/Route.kt
+++ b/app/src/main/java/com/nibalk/tasky/navigation/Route.kt
@@ -20,3 +20,21 @@ object AgendaNavigationGraph
 
 @Serializable
 object AgendaHomeScreen
+
+@Serializable
+data class AgendaEventScreen(
+    val isEditable: Boolean,
+    val agendaId: String?
+)
+
+@Serializable
+data class AgendaTaskScreen(
+    val isEditable: Boolean,
+    val agendaId: String?
+)
+
+@Serializable
+data class AgendaReminderScreen(
+    val isEditable: Boolean,
+    val agendaId: String?
+)

--- a/auth/presentation/src/main/java/com/nibalk/tasky/auth/presentation/login/LoginScreen.kt
+++ b/auth/presentation/src/main/java/com/nibalk/tasky/auth/presentation/login/LoginScreen.kt
@@ -45,20 +45,11 @@ fun LoginScreenRoot(
         when(event) {
             is LoginEvent.LoginError -> {
                 keyboardController?.hide()
-                Toast.makeText(
-                    context,
-                    event.error.asString(context),
-                    Toast.LENGTH_LONG
-                ).show()
+                Toast.makeText(context, event.error.asString(context), Toast.LENGTH_LONG).show()
             }
             LoginEvent.LoginSuccess -> {
                 keyboardController?.hide()
-                Toast.makeText(
-                    context,
-                    R.string.auth_login_successful,
-                    Toast.LENGTH_LONG
-                ).show()
-
+                Toast.makeText(context, R.string.auth_login_success, Toast.LENGTH_SHORT).show()
                 onSuccessfulLogin()
             }
         }

--- a/auth/presentation/src/main/java/com/nibalk/tasky/auth/presentation/register/RegisterScreen.kt
+++ b/auth/presentation/src/main/java/com/nibalk/tasky/auth/presentation/register/RegisterScreen.kt
@@ -47,19 +47,11 @@ fun RegisterScreenRoot(
         when(event) {
             is RegisterEvent.RegistrationError -> {
                 keyboardController?.hide()
-                Toast.makeText(
-                    context,
-                    event.error.asString(context),
-                    Toast.LENGTH_LONG
-                ).show()
+                Toast.makeText(context, event.error.asString(context), Toast.LENGTH_LONG).show()
             }
             RegisterEvent.RegistrationSuccess -> {
                 keyboardController?.hide()
-                Toast.makeText(
-                    context,
-                    R.string.auth_registration_successful,
-                    Toast.LENGTH_LONG
-                ).show()
+                Toast.makeText(context, R.string.auth_registration_success, Toast.LENGTH_SHORT).show()
                 onSuccessfulRegistration()
             }
         }

--- a/auth/presentation/src/main/res/values/strings.xml
+++ b/auth/presentation/src/main/res/values/strings.xml
@@ -9,8 +9,8 @@
     <string name="auth_sign_up">Sign up</string>
     <string name="auth_get_started">Get Started</string>
     <string name="auth_login">Login</string>
-    <string name="auth_registration_successful">Registration successful! You can log in now.</string>
-    <string name="auth_login_successful">You\'re logged in.</string>
+    <string name="auth_registration_success">Registration successful! You can log in now.</string>
+    <string name="auth_login_success">You\'re logged in.</string>
 
     <!-- Auth Module Errors -->
     <string name="auth_must_enter_email">Must enter email</string>

--- a/core/presentation/src/main/java/com/nibalk/tasky/core/presentation/components/TaskyEmptyList.kt
+++ b/core/presentation/src/main/java/com/nibalk/tasky/core/presentation/components/TaskyEmptyList.kt
@@ -1,0 +1,60 @@
+package com.nibalk.tasky.core.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.nibalk.tasky.core.presentation.themes.TaskyDarkGray
+import com.nibalk.tasky.core.presentation.themes.TaskyTheme
+import com.nibalk.tasky.core.presentation.themes.spacing
+
+@Composable
+fun TaskyEmptyList(
+    modifier: Modifier = Modifier,
+    contentColor: Color,
+    displayMessage: String,
+    displayIcon: Painter,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            painter = displayIcon,
+            contentDescription = "empty list",
+            tint = contentColor,
+        )
+        Spacer(modifier = Modifier.height(MaterialTheme.spacing.spaceMedium))
+        Text(
+            text = displayMessage,
+            style = MaterialTheme.typography.displayMedium,
+            color = contentColor,
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
+@Composable
+private fun TaskyEmptyListPreview() {
+    TaskyTheme {
+        TaskyEmptyList(
+            displayMessage = "No agenda items for this day",
+            displayIcon = painterResource(android.R.drawable.ic_menu_agenda),
+            contentColor = TaskyDarkGray
+        )
+    }
+}

--- a/core/presentation/src/main/java/com/nibalk/tasky/core/presentation/components/TaskyNeedleSeparator.kt
+++ b/core/presentation/src/main/java/com/nibalk/tasky/core/presentation/components/TaskyNeedleSeparator.kt
@@ -55,6 +55,5 @@ fun TaskyNeedleSeparator(
 private fun TaskyNeedleSeparatorPreview() {
     TaskyTheme {
         TaskyNeedleSeparator()
-
     }
 }

--- a/core/presentation/src/main/java/com/nibalk/tasky/core/presentation/components/TaskyNeedleSeparator.kt
+++ b/core/presentation/src/main/java/com/nibalk/tasky/core/presentation/components/TaskyNeedleSeparator.kt
@@ -1,0 +1,60 @@
+package com.nibalk.tasky.core.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.nibalk.tasky.core.presentation.themes.TaskyBlack
+import com.nibalk.tasky.core.presentation.themes.TaskyTheme
+
+@Composable
+fun TaskyNeedleSeparator(
+    modifier: Modifier = Modifier,
+    color: Color = TaskyBlack,
+    circleRadius: Dp = 5.dp,
+    strokeHeight: Dp = 4.dp,
+) {
+    Row(
+        modifier = modifier
+            .height(circleRadius)
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Box(
+            modifier = Modifier
+                .size(circleRadius)
+                .background(color, CircleShape)
+                .align(Alignment.CenterVertically),
+        )
+        HorizontalDivider(
+            modifier = Modifier
+                .height(strokeHeight)
+                .padding(top = 1.dp)
+                .align(Alignment.CenterVertically),
+            color = color
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
+@Composable
+private fun TaskyNeedleSeparatorPreview() {
+    TaskyTheme {
+        TaskyNeedleSeparator()
+
+    }
+}

--- a/core/presentation/src/main/java/com/nibalk/tasky/core/presentation/components/TaskyPasswordTextField.kt
+++ b/core/presentation/src/main/java/com/nibalk/tasky/core/presentation/components/TaskyPasswordTextField.kt
@@ -41,6 +41,7 @@ import com.nibalk.tasky.core.presentation.R
 import com.nibalk.tasky.core.presentation.themes.EyeClosedIcon
 import com.nibalk.tasky.core.presentation.themes.EyeOpenedIcon
 import com.nibalk.tasky.core.presentation.themes.TaskyTheme
+import com.nibalk.tasky.core.presentation.themes.spacing
 
 @Composable
 fun TaskyPasswordTextField(
@@ -93,7 +94,7 @@ fun TaskyPasswordTextField(
                         .fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Spacer(modifier = Modifier.width(16.dp))
+                    Spacer(modifier = Modifier.width(MaterialTheme.spacing.spaceMedium))
                     Box(
                         modifier = Modifier
                             .weight(1f)
@@ -123,7 +124,7 @@ fun TaskyPasswordTextField(
                 }
             }
         )
-        Spacer(modifier = Modifier.height(4.dp))
+        Spacer(modifier = Modifier.height(MaterialTheme.spacing.spaceExtraSmall))
         Row(
             modifier = Modifier
                 .fillMaxWidth(),

--- a/core/presentation/src/main/java/com/nibalk/tasky/core/presentation/components/TaskyTextField.kt
+++ b/core/presentation/src/main/java/com/nibalk/tasky/core/presentation/components/TaskyTextField.kt
@@ -105,7 +105,7 @@ fun TaskyTextField(
                         innerBox()
                     }
                     if(endIcon != null) {
-                        Spacer(modifier = Modifier.width(16.dp))
+                        Spacer(modifier = Modifier.width(MaterialTheme.spacing.spaceMedium))
                         Icon(
                             imageVector = endIcon,
                             contentDescription = null,
@@ -117,7 +117,7 @@ fun TaskyTextField(
                 }
             }
         )
-        Spacer(modifier = Modifier.height(4.dp))
+        Spacer(modifier = Modifier.height(MaterialTheme.spacing.spaceExtraSmall))
         Row(
             modifier = Modifier
                 .fillMaxWidth(),

--- a/core/presentation/src/main/java/com/nibalk/tasky/core/presentation/themes/Type.kt
+++ b/core/presentation/src/main/java/com/nibalk/tasky/core/presentation/themes/Type.kt
@@ -86,7 +86,7 @@ val Typography = Typography(
     labelLarge = TextStyle(
         fontFamily = Inter,
         fontWeight = FontWeight.Bold,
-        fontSize = 16.sp,
+        fontSize = 18.sp,
         lineHeight = 30.sp,
     ),
     labelMedium = TextStyle(
@@ -102,7 +102,8 @@ val Typography = Typography(
     ),
     displaySmall = TextStyle(
         fontFamily = Inter,
-        fontWeight = FontWeight.Light,
-        fontSize = 14.sp
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 18.sp,
     ),
 )

--- a/core/presentation/src/main/res/values/strings.xml
+++ b/core/presentation/src/main/res/values/strings.xml
@@ -1,4 +1,8 @@
 <resources>
+    <!-- Toast -->
+    <string name="toast_message_clicked">Clicked!</string>
+    <string name="toast_message_add">Add</string>
+
     <!-- Content Descriptions -->
     <string name="content_description_back">Back</string>
     <string name="content_description_show_password_text">Show Password</string>

--- a/test/src/main/java/com/nibalk/tasky/test/mock/AgendaSampleData.kt
+++ b/test/src/main/java/com/nibalk/tasky/test/mock/AgendaSampleData.kt
@@ -7,7 +7,7 @@ object AgendaSampleData {
 
     // Events
     val event1 = AgendaItem.Event(
-        id = "",
+        id = "E01",
         title = "Tasky Event - Attend Google I/O 1",
         description = "Attend Google I/O event to learn what's new in Android",
         startAt = LocalDateTime.now(),
@@ -17,7 +17,7 @@ object AgendaSampleData {
         isHost = false,
     )
     val event2 = AgendaItem.Event(
-        id = "",
+        id = "E02",
         title = "Tasky Event - Attend Google I/O 2",
         description = "Attend Google I/O event to learn what's new in Android",
         startAt = LocalDateTime.now().plusDays(1),
@@ -27,7 +27,7 @@ object AgendaSampleData {
         isHost = false,
     )
     val event3 = AgendaItem.Event(
-        id = "",
+        id = "E03",
         title = "Tasky Event - Attend Google I/O 3",
         description = "Attend Google I/O event to learn what's new in Android",
         startAt = LocalDateTime.now().plusDays(2),
@@ -37,7 +37,7 @@ object AgendaSampleData {
         isHost = false,
     )
     val event4 = AgendaItem.Event(
-        id = "",
+        id = "E04",
         title = "Tasky Event - Attend Google I/O 4",
         description = "Attend Google I/O event to learn what's new in Android",
         startAt = LocalDateTime.now().plusDays(2),
@@ -47,7 +47,7 @@ object AgendaSampleData {
         isHost = false,
     )
     val event5 = AgendaItem.Event(
-        id = "",
+        id = "E05",
         title = "Tasky Event - Attend Google I/O 5",
         description = "Attend Google I/O event to learn what's new in Android",
         startAt = LocalDateTime.now().plusHours(7),
@@ -59,7 +59,7 @@ object AgendaSampleData {
 
     // Tasks
     val task1 = AgendaItem.Task(
-        id = "",
+        id = "T01",
         title = "Tasky Project - Complete Auth Feature 1",
         description = "Completing the Auth feature including the Login and Register flows",
         startAt = LocalDateTime.now(),
@@ -67,7 +67,7 @@ object AgendaSampleData {
         isDone = true
     )
     val task2 = AgendaItem.Task(
-        id = "",
+        id = "T02",
         title = "Tasky Project - Complete Auth Feature 2",
         description = "Completing the Auth feature including the Login and Register flows",
         startAt = LocalDateTime.now().plusDays(3),
@@ -75,7 +75,7 @@ object AgendaSampleData {
         isDone = true
     )
     val task3 = AgendaItem.Task(
-        id = "",
+        id = "T03",
         title = "Tasky Project - Complete Auth Feature 2",
         description = "Completing the Auth feature including the Login and Register flows",
         startAt = LocalDateTime.now().plusDays(3),
@@ -83,7 +83,7 @@ object AgendaSampleData {
         isDone = true
     )
     val task4 = AgendaItem.Task(
-        id = "",
+        id = "T04",
         title = "Tasky Project - Complete Auth Feature 4",
         description = "Completing the Auth feature including the Login and Register flows",
         startAt = LocalDateTime.now().plusDays(4),
@@ -91,7 +91,7 @@ object AgendaSampleData {
         isDone = true
     )
     val task5 = AgendaItem.Task(
-        id = "",
+        id = "T05",
         title = "Tasky Project - Complete Auth Feature 5",
         description = "Completing the Auth feature including the Login and Register flows",
         startAt = LocalDateTime.now().plusHours(9),
@@ -101,35 +101,35 @@ object AgendaSampleData {
 
     // Reminders
     val reminder1 =  AgendaItem.Reminder(
-        id = "",
+        id = "R01",
         title = "Tasky Reminder - Weekly call 1",
         description = "Bi-weekly call",
         startAt = LocalDateTime.now().plusHours(2),
         remindAt = LocalDateTime.now(),
     )
     val reminder2 = AgendaItem.Reminder(
-        id = "",
+        id = "R02",
         title = "Tasky Reminder - Weekly call 2",
         description = "Bi-weekly call",
         startAt = LocalDateTime.now().plusHours(5),
         remindAt = LocalDateTime.now(),
     )
     val reminder3 = AgendaItem.Reminder(
-        id = "",
+        id = "R03",
         title = "Tasky Reminder - Weekly call 3",
         description = "Bi-weekly call",
         startAt = LocalDateTime.now().plusDays(1),
         remindAt = LocalDateTime.now(),
     )
     val reminder4 = AgendaItem.Reminder(
-        id = "",
+        id = "R04",
         title = "Tasky Reminder - Weekly call 4",
         description = "Bi-weekly call",
         startAt = LocalDateTime.now().plusDays(1).plusHours(3),
         remindAt = LocalDateTime.now(),
     )
     val reminder5 =  AgendaItem.Reminder(
-        id = "",
+        id = "R05",
         title = "Tasky Reminder - Weekly call 5",
         description = "Bi-weekly call",
         startAt = LocalDateTime.now().plusDays(2).plusHours(2),

--- a/test/src/main/java/com/nibalk/tasky/test/mock/AgendaSampleData.kt
+++ b/test/src/main/java/com/nibalk/tasky/test/mock/AgendaSampleData.kt
@@ -8,8 +8,8 @@ object AgendaSampleData {
     // Events
     val event1 = AgendaItem.Event(
         id = "E01",
-        title = "Tasky Event - Attend Google I/O 1",
-        description = "Attend Google I/O event to learn what's new in Android",
+        title = "Tasky Event - Attend 2024 Google I/O 1",
+        description = "Attend Google I/O event to learn what is new in Android",
         startAt = LocalDateTime.now(),
         remindAt = LocalDateTime.now(),
         endAt = LocalDateTime.now(),
@@ -18,8 +18,8 @@ object AgendaSampleData {
     )
     val event2 = AgendaItem.Event(
         id = "E02",
-        title = "Tasky Event - Attend Google I/O 2",
-        description = "Attend Google I/O event to learn what's new in Android",
+        title = "Tasky Event - Attend 2024 Google I/O 2",
+        description = "Attend Google I/O event to learn what is new in Android",
         startAt = LocalDateTime.now().plusDays(1),
         remindAt = LocalDateTime.now(),
         endAt = LocalDateTime.now(),
@@ -28,8 +28,8 @@ object AgendaSampleData {
     )
     val event3 = AgendaItem.Event(
         id = "E03",
-        title = "Tasky Event - Attend Google I/O 3",
-        description = "Attend Google I/O event to learn what's new in Android",
+        title = "Tasky Event - Attend 2024 Google I/O 3",
+        description = "Attend Google I/O event to learn what is new in Android",
         startAt = LocalDateTime.now().plusDays(2),
         remindAt = LocalDateTime.now(),
         endAt = LocalDateTime.now(),
@@ -38,8 +38,8 @@ object AgendaSampleData {
     )
     val event4 = AgendaItem.Event(
         id = "E04",
-        title = "Tasky Event - Attend Google I/O 4",
-        description = "Attend Google I/O event to learn what's new in Android",
+        title = "Tasky Event - Attend 2024 Google I/O 4",
+        description = "Attend Google I/O event to learn what is new in Android",
         startAt = LocalDateTime.now().plusDays(2),
         remindAt = LocalDateTime.now(),
         endAt = LocalDateTime.now(),
@@ -48,8 +48,8 @@ object AgendaSampleData {
     )
     val event5 = AgendaItem.Event(
         id = "E05",
-        title = "Tasky Event - Attend Google I/O 5",
-        description = "Attend Google I/O event to learn what's new in Android",
+        title = "Tasky Event - Attend 2024 Google I/O 5",
+        description = "Attend Google I/O event to learn what is new in Android",
         startAt = LocalDateTime.now().plusHours(7),
         remindAt = LocalDateTime.now(),
         endAt = LocalDateTime.now(),


### PR DESCRIPTION
### Week 06 PR 03 - Remaining UI changes in Agenda Home screen

**What is done
==========**

- Add more options menu to agenda items in Home screen
- Add needle component to separate past and upcoming agendas in Home screen list
- Add empty list component to display when there are no agendas for a given date in Home screen

**Need Clarification
===============**
Now with the type-safe navigation, in my [NavigationRoot](https://github.com/nibalk/Tasky/pull/20/files#diff-4401c5c8744ca8aacebf9f4f64eb7da3b41fb3b164e66a33df6de7d7bc4500eb) , if `agendaId` is empty, app will crash with the below error. 

Having `agendaId = null` is **fine**. But having `agendaId =""` is causing IllegalArgumentException as shown below.

This is my first time using type-safe navigation and I'm not sure why EMPTY string causing an app crash in this case.
Appreciate your inputs on this. 😄 

```
@Serializable
data class AgendaEventScreen(
    val isEditable: Boolean,
    val agendaId: String?
)
```

<img width="908" alt="Screenshot 2024-07-11 at 2 47 26 PM" src="https://github.com/nibalk/Tasky/assets/5864797/ce2d5050-df4a-4e98-bd5e-0fdfc90438be">


> java.lang.IllegalArgumentException: Navigation destination that matches request NavDeepLinkRequest{ uri=android-app://androidx.navigation/com.nibalk.tasky.navigation.AgendaEventScreen/false/ } cannot be found in the navigation graph ComposeNavGraph(0x0) startDestination={ComposeNavGraph(0x103c49) route=com.nibalk.tasky.navigation.AgendaNavigationGraph startDestination={Destination(0x2be194e) route=com.nibalk.tasky.navigation.AgendaHomeScreen}}
                                                                                                    
 
**Next Steps
==========**

Test the access token expiry flow
Fix the loader issue in pull-to-refresh list
Create detail screens for task, Event, Reminder

