### PR TITLE
10.02 saving pending syncs

### DIFF
--- a/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/local/dao/EventSyncDao.kt
+++ b/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/local/dao/EventSyncDao.kt
@@ -1,0 +1,42 @@
+package com.nibalk.tasky.agenda.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import com.nibalk.tasky.agenda.data.local.entity.EventDeletionSyncEntity
+import com.nibalk.tasky.agenda.data.local.entity.EventPendingSyncEntity
+
+@Dao
+interface EventSyncDao {
+
+    // Events created offline
+
+    @Query("SELECT * FROM ${EventPendingSyncEntity.TABLE_NAME} " +
+        "WHERE ${EventPendingSyncEntity.USER_ID_KEY} = :userId")
+    suspend fun getAllEventPendingSyncEntities(userId: String): List<EventPendingSyncEntity>
+
+    @Query("SELECT * FROM ${EventPendingSyncEntity.TABLE_NAME} " +
+        "WHERE ${EventPendingSyncEntity.PRIMARY_KEY} = :eventId")
+    suspend fun getEventPendingSyncEntity(eventId: String): EventPendingSyncEntity?
+
+    @Upsert
+    suspend fun upsertEventPendingSyncEntity(entity: EventPendingSyncEntity)
+
+    @Query("DELETE FROM ${EventPendingSyncEntity.TABLE_NAME} " +
+        "WHERE ${EventPendingSyncEntity.PRIMARY_KEY} = :eventId")
+    suspend fun deleteEventPendingSyncEntity(eventId: String)
+
+
+    // Events deleted offline
+
+    @Query("SELECT * FROM ${EventDeletionSyncEntity.TABLE_NAME} " +
+        "WHERE ${EventDeletionSyncEntity.PRIMARY_KEY} = :userId")
+    suspend fun getAllEventDeletionSyncEntities(userId: String): List<EventDeletionSyncEntity>
+
+    @Upsert
+    suspend fun upsertEventDeletionSyncEntity(entity: EventDeletionSyncEntity)
+
+    @Query("DELETE FROM ${EventDeletionSyncEntity.TABLE_NAME} " +
+        "WHERE ${EventDeletionSyncEntity.PRIMARY_KEY} = :eventId")
+    suspend fun deleteEventDeletionSyncEntity(eventId: String)
+}

--- a/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/local/dao/ReminderSyncDao.kt
+++ b/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/local/dao/ReminderSyncDao.kt
@@ -1,0 +1,42 @@
+package com.nibalk.tasky.agenda.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import com.nibalk.tasky.agenda.data.local.entity.ReminderDeletionSyncEntity
+import com.nibalk.tasky.agenda.data.local.entity.ReminderPendingSyncEntity
+
+@Dao
+interface ReminderSyncDao {
+
+    // Reminders created offline
+
+    @Query("SELECT * FROM ${ReminderPendingSyncEntity.TABLE_NAME} " +
+        "WHERE ${ReminderPendingSyncEntity.USER_ID_KEY} = :userId")
+    suspend fun getAllReminderPendingSyncEntities(userId: String): List<ReminderPendingSyncEntity>
+
+    @Query("SELECT * FROM ${ReminderPendingSyncEntity.TABLE_NAME} " +
+        "WHERE ${ReminderPendingSyncEntity.PRIMARY_KEY} = :reminderId")
+    suspend fun getReminderPendingSyncEntity(reminderId: String): ReminderPendingSyncEntity?
+
+    @Upsert
+    suspend fun upsertReminderPendingSyncEntity(entity: ReminderPendingSyncEntity)
+
+    @Query("DELETE FROM ${ReminderPendingSyncEntity.TABLE_NAME} " +
+        "WHERE ${ReminderPendingSyncEntity.PRIMARY_KEY} = :reminderId")
+    suspend fun deleteReminderPendingSyncEntity(reminderId: String)
+
+
+    // Reminders deleted offline
+
+    @Query("SELECT * FROM ${ReminderDeletionSyncEntity.TABLE_NAME} " +
+        "WHERE ${ReminderDeletionSyncEntity.PRIMARY_KEY} = :userId")
+    suspend fun getAllReminderDeletionSyncEntities(userId: String): List<ReminderDeletionSyncEntity>
+
+    @Upsert
+    suspend fun upsertReminderDeletionSyncEntity(entity: ReminderDeletionSyncEntity)
+
+    @Query("DELETE FROM ${ReminderDeletionSyncEntity.TABLE_NAME} " +
+        "WHERE ${ReminderDeletionSyncEntity.PRIMARY_KEY} = :reminderId")
+    suspend fun deleteReminderDeletionSyncEntity(reminderId: String)
+}

--- a/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/local/dao/TaskSyncDao.kt
+++ b/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/local/dao/TaskSyncDao.kt
@@ -1,0 +1,42 @@
+package com.nibalk.tasky.agenda.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import com.nibalk.tasky.agenda.data.local.entity.TaskDeletionSyncEntity
+import com.nibalk.tasky.agenda.data.local.entity.TaskPendingSyncEntity
+
+@Dao
+interface TaskSyncDao {
+
+    // Tasks created offline
+
+    @Query("SELECT * FROM ${TaskPendingSyncEntity.TABLE_NAME} " +
+        "WHERE ${TaskPendingSyncEntity.USER_ID_KEY} = :userId")
+    suspend fun getAllTaskPendingSyncEntities(userId: String): List<TaskPendingSyncEntity>
+
+    @Query("SELECT * FROM ${TaskPendingSyncEntity.TABLE_NAME} " +
+        "WHERE ${TaskPendingSyncEntity.PRIMARY_KEY} = :taskId")
+    suspend fun getTaskPendingSyncEntity(taskId: String): TaskPendingSyncEntity?
+
+    @Upsert
+    suspend fun upsertTaskPendingSyncEntity(entity: TaskPendingSyncEntity)
+
+    @Query("DELETE FROM ${TaskPendingSyncEntity.TABLE_NAME} " +
+        "WHERE ${TaskPendingSyncEntity.PRIMARY_KEY} = :taskId")
+    suspend fun deleteTaskPendingSyncEntity(taskId: String)
+
+
+    // Tasks deleted offline
+
+    @Query("SELECT * FROM ${TaskDeletionSyncEntity.TABLE_NAME} " +
+        "WHERE ${TaskDeletionSyncEntity.PRIMARY_KEY} = :userId")
+    suspend fun getAllTaskDeletionSyncEntities(userId: String): List<TaskDeletionSyncEntity>
+
+    @Upsert
+    suspend fun upsertTaskDeletionSyncEntity(entity: TaskDeletionSyncEntity)
+
+    @Query("DELETE FROM ${TaskDeletionSyncEntity.TABLE_NAME} " +
+        "WHERE ${TaskDeletionSyncEntity.PRIMARY_KEY} = :taskId")
+    suspend fun deleteTaskDeletionSyncEntity(taskId: String)
+}

--- a/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/local/entity/EventDeletionSyncEntity.kt
+++ b/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/local/entity/EventDeletionSyncEntity.kt
@@ -1,0 +1,20 @@
+package com.nibalk.tasky.agenda.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = EventDeletionSyncEntity.TABLE_NAME)
+data class EventDeletionSyncEntity(
+    @PrimaryKey(autoGenerate = false)
+    @ColumnInfo(name = PRIMARY_KEY)
+    val eventId: String,
+    @ColumnInfo(name = USER_ID_KEY)
+    val userId: String
+) {
+    companion object {
+        const val TABLE_NAME = "event_deletion_sync"
+        const val PRIMARY_KEY = "eventId"
+        const val USER_ID_KEY = "userId"
+    }
+}

--- a/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/local/entity/EventPendingSyncEntity.kt
+++ b/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/local/entity/EventPendingSyncEntity.kt
@@ -1,0 +1,22 @@
+package com.nibalk.tasky.agenda.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Embedded
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = EventPendingSyncEntity.TABLE_NAME)
+data class EventPendingSyncEntity(
+    @Embedded val event: EventEntity,
+    @PrimaryKey(autoGenerate = false)
+    @ColumnInfo(name = PRIMARY_KEY)
+    val eventId: String = event.id,
+    val localPhotos: List<ByteArray>,
+    @ColumnInfo(name = USER_ID_KEY) val userId: String,
+) {
+    companion object {
+        const val TABLE_NAME = "event_pending_sync"
+        const val PRIMARY_KEY = "eventId"
+        const val USER_ID_KEY = "userId"
+    }
+}

--- a/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/local/entity/ReminderDeletionSyncEntity.kt
+++ b/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/local/entity/ReminderDeletionSyncEntity.kt
@@ -1,0 +1,20 @@
+package com.nibalk.tasky.agenda.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = ReminderDeletionSyncEntity.TABLE_NAME)
+data class ReminderDeletionSyncEntity(
+    @PrimaryKey(autoGenerate = false)
+    @ColumnInfo(name = PRIMARY_KEY)
+    val reminderId: String,
+    @ColumnInfo(name = USER_ID_KEY)
+    val userId: String
+) {
+    companion object {
+        const val TABLE_NAME = "reminder_deletion_sync"
+        const val PRIMARY_KEY = "reminderId"
+        const val USER_ID_KEY = "userId"
+    }
+}

--- a/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/local/entity/ReminderPendingSyncEntity.kt
+++ b/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/local/entity/ReminderPendingSyncEntity.kt
@@ -1,0 +1,22 @@
+package com.nibalk.tasky.agenda.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Embedded
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = ReminderPendingSyncEntity.TABLE_NAME)
+data class ReminderPendingSyncEntity(
+    @Embedded val reminder: ReminderEntity,
+    @PrimaryKey(autoGenerate = false)
+    @ColumnInfo(name = PRIMARY_KEY)
+    val reminderId: String = reminder.id,
+    @ColumnInfo(name = USER_ID_KEY)
+    val userId: String
+) {
+    companion object {
+        const val TABLE_NAME = "reminder_pending_sync"
+        const val PRIMARY_KEY = "reminderId"
+        const val USER_ID_KEY = "userId"
+    }
+}

--- a/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/local/entity/TaskDeletionSyncEntity.kt
+++ b/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/local/entity/TaskDeletionSyncEntity.kt
@@ -1,0 +1,20 @@
+package com.nibalk.tasky.agenda.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = TaskDeletionSyncEntity.TABLE_NAME)
+data class TaskDeletionSyncEntity(
+    @PrimaryKey(autoGenerate = false)
+    @ColumnInfo(name = PRIMARY_KEY)
+    val taskId: String,
+    @ColumnInfo(name = USER_ID_KEY)
+    val userId: String
+) {
+    companion object {
+        const val TABLE_NAME = "task_deletion_sync"
+        const val PRIMARY_KEY = "taskId"
+        const val USER_ID_KEY = "userId"
+    }
+}

--- a/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/local/entity/TaskPendingSyncEntity.kt
+++ b/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/local/entity/TaskPendingSyncEntity.kt
@@ -1,0 +1,22 @@
+package com.nibalk.tasky.agenda.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Embedded
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = TaskPendingSyncEntity.TABLE_NAME)
+data class TaskPendingSyncEntity(
+    @Embedded val task: TaskEntity,
+    @PrimaryKey(autoGenerate = false)
+    @ColumnInfo(name = PRIMARY_KEY)
+    val taskId: String = task.id,
+    @ColumnInfo(name = USER_ID_KEY)
+    val userId: String
+) {
+    companion object {
+        const val TABLE_NAME = "task_pending_sync"
+        const val PRIMARY_KEY = "taskId"
+        const val USER_ID_KEY = "userId"
+    }
+}

--- a/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/remote/dto/EventRequestDto.kt
+++ b/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/remote/dto/EventRequestDto.kt
@@ -27,8 +27,6 @@ data class EventRequestForUpdateDto(
     @SerialName("remindAt") val remindAt: Long,
     @SerialName("to") val endAt: Long,
     @SerialName("attendeeIds") @Required val attendeeIds: List<AttendeeId> = emptyList(),
-    @SerialName("deletedPhotoKeys") val deletedPhotoKeys: List<PhotoKey> = emptyList(),
+    @SerialName("deletedPhotoKeys") @Required val deletedPhotoKeys: List<PhotoKey> = emptyList(),
     @SerialName("isGoing") val isGoing: Boolean,
-
-
 )

--- a/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/remote/source/RetrofitRemoteEventDataSource.kt
+++ b/agenda/data/src/main/java/com/nibalk/tasky/agenda/data/remote/source/RetrofitRemoteEventDataSource.kt
@@ -73,7 +73,7 @@ class RetrofitRemoteEventDataSource(
     override suspend fun updateEvent(
         event: AgendaItem.Event
     ): Result<AgendaItem.Event?, DataError.Network> {
-        Timber.d("[OfflineFirst-ImageIssue] REMOTE | Create EVENT (%s)", event.photos)
+        Timber.d("[OfflineFirst-ImageIssue] REMOTE | Update EVENT (%s)", event.photos)
         val formData = Json.encodeToString(event.toEventRequestForUpdateDto())
         val nextIndex = event.photos
             .filterIsInstance<EventPhoto.Remote>()
@@ -102,7 +102,7 @@ class RetrofitRemoteEventDataSource(
                     name = "update_event_request",
                     value = formData
                 ),
-                photos = emptyList()
+                photos = photoData
             )
         }
 

--- a/agenda/domain/src/main/java/com/nibalk/tasky/agenda/domain/model/SyncEvent.kt
+++ b/agenda/domain/src/main/java/com/nibalk/tasky/agenda/domain/model/SyncEvent.kt
@@ -1,0 +1,24 @@
+package com.nibalk.tasky.agenda.domain.model
+
+data class SyncPendingEvent(
+    val userId: String,
+    val event: AgendaItem.Event,
+    val localPhotos: List<ByteArray>,
+)
+
+data class SyncPendingReminder(
+    val userId: String,
+    val reminder: AgendaItem.Reminder,
+    val localPhotos: List<ByteArray>,
+)
+
+data class SyncPendingTask(
+    val userId: String,
+    val task: AgendaItem.Task,
+    val localPhotos: List<ByteArray>,
+)
+
+data class SyncDeletionAgendaItem(
+    val userId: String,
+    val agendaId: String,
+)


### PR DESCRIPTION
### Week 10 PR 02 - Saving pending syncs

**What is done
==========**
Fix the update issue in events flow
Added created and deleted pending sync dao and entities

**Tested flows
==========**

- [x] Create event/task/reminder in Device A
- [x] Login newly to device B and check the above created
- [x] Update event/task/reminder in Device A
- [x] Login newly to device B and check the above updated
- [x] Delete event/task/reminder in Device A
- [x] Login newly to device B and check the above deleted
- [x] Create event with some photos uploaded in Device A
- [ ] Update event with some photos uploaded in Device A

**Next Steps
==========**
Test the access token expiry flow
Use ZonedDateTime to handle timezone information in the date time instance. ([PR](https://github.com/nibalk/Tasky/pull/30))
Domain model feedback in previous [PR](https://github.com/nibalk/Tasky/pull/33)
Move photo loading to VM feedback in previous [PR](https://github.com/nibalk/Tasky/pull/36#discussion_r1703120368)
Offline syncing